### PR TITLE
Potential fix for code scanning alert no. 5: Flask app is run in debug mode

### DIFF
--- a/servers/sever_2.py
+++ b/servers/sever_2.py
@@ -1,6 +1,8 @@
 from flask import Flask, send_from_directory
 import os
 
+FLASK_DEBUG = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+
 app = Flask(__name__)
 
 @app.route('/')
@@ -16,4 +18,4 @@ def get_file(filename):
     return send_from_directory('.', filename, as_attachment=False)
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=8000)
+    app.run(debug=FLASK_DEBUG, host='0.0.0.0', port=8000)


### PR DESCRIPTION
Potential fix for [https://github.com/chanithacri/python/security/code-scanning/5](https://github.com/chanithacri/python/security/code-scanning/5)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode setting. This way, we can set the environment variable to enable debug mode during development and disable it in production.

1. Import the `os` module to access environment variables.
2. Use an environment variable (e.g., `FLASK_DEBUG`) to control the debug mode setting.
3. Modify the `app.run` call to use the value of the environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
